### PR TITLE
feat: Implementar múltiples partidos por quedada

### DIFF
--- a/lib/data/models/quedada_model.dart
+++ b/lib/data/models/quedada_model.dart
@@ -1,37 +1,63 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+class Partido {
+  final List<String> equipo1;
+  final List<String> equipo2;
+  final String estado; // e.g., 'disponible', 'en juego', 'finalizado'
+  final Map<String, int>? resultado;
+
+  Partido({
+    required this.equipo1,
+    required this.equipo2,
+    this.estado = 'disponible',
+    this.resultado,
+  });
+
+  factory Partido.fromMap(Map<String, dynamic> map) {
+    return Partido(
+      equipo1: List<String>.from(map['equipo1'] ?? []),
+      equipo2: List<String>.from(map['equipo2'] ?? []),
+      estado: map['estado'] ?? 'disponible',
+      resultado: Map<String, int>.from(map['resultado'] ?? {}),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'equipo1': equipo1,
+      'equipo2': equipo2,
+      'estado': estado,
+      'resultado': resultado,
+    };
+  }
+}
+
 class Quedada {
   final String id;
   final String lugar;
   final DateTime fecha;
   final String hora;
-  final List<String> jugadores;
-  final List<String> equipo1;
-  final List<String> equipo2;
-  final String estadoQuedada;
+  final List<Partido> partidos;
 
   Quedada({
     required this.id,
     required this.lugar,
     required this.fecha,
     required this.hora,
-    required this.jugadores,
-    required this.equipo1,
-    required this.equipo2,
-    this.estadoQuedada = 'disponible',
+    required this.partidos,
   });
 
   factory Quedada.fromFirestore(DocumentSnapshot doc) {
     Map data = doc.data() as Map<String, dynamic>;
+    var partidosData = data['partidos'] as List<dynamic>? ?? [];
+    List<Partido> partidos = partidosData.map((partidoData) => Partido.fromMap(partidoData)).toList();
+
     return Quedada(
       id: doc.id,
       lugar: data['lugar'] ?? '',
       fecha: (data['fecha'] as Timestamp).toDate(),
       hora: data['hora'] ?? '',
-      jugadores: List<String>.from(data['jugadores'] ?? []),
-      equipo1: List<String>.from(data['equipo1'] ?? []),
-      equipo2: List<String>.from(data['equipo2'] ?? []),
-      estadoQuedada: data['estadoQuedada'] ?? 'disponible',
+      partidos: partidos,
     );
   }
 
@@ -40,10 +66,7 @@ class Quedada {
       'lugar': lugar,
       'fecha': fecha,
       'hora': hora,
-      'jugadores': jugadores,
-      'equipo1': equipo1,
-      'equipo2': equipo2,
-      'estadoQuedada': estadoQuedada,
+      'partidos': partidos.map((p) => p.toMap()).toList(),
     };
   }
 }

--- a/lib/features/pages/home_page.dart
+++ b/lib/features/pages/home_page.dart
@@ -40,21 +40,56 @@ class _HomePageState extends State<HomePage> {
     final quedadasRef = FirebaseFirestore.instance.collection('quedadas');
     final snapshot = await quedadasRef.limit(1).get();
     if (snapshot.docs.isEmpty) {
+      // Quedada de las 8:00 AM con 6 partidos
       await quedadasRef.add({
-        'lugar': 'Padel Club Indoor',
+        'lugar': 'El Maracaná',
+        'fecha': Timestamp.now(),
+        'hora': '08:00',
+        'partidos': List.generate(6, (index) => {
+          'equipo1': [],
+          'equipo2': [],
+          'estado': 'disponible',
+          'resultado': null,
+        }),
+      });
+
+      // Quedada de las 10:00 AM con 6 partidos
+      await quedadasRef.add({
+        'lugar': 'El Maracaná',
+        'fecha': Timestamp.now(),
+        'hora': '10:00',
+        'partidos': List.generate(6, (index) => {
+          'equipo1': [],
+          'equipo2': [],
+          'estado': 'disponible',
+          'resultado': null,
+        }),
+      });
+
+      // Quedada de las 2:00 PM con 6 partidos
+      await quedadasRef.add({
+        'lugar': 'El Maracaná',
+        'fecha': Timestamp.now(),
+        'hora': '14:00',
+        'partidos': List.generate(6, (index) => {
+          'equipo1': [],
+          'equipo2': [],
+          'estado': 'disponible',
+          'resultado': null,
+        }),
+      });
+
+      // Quedada de las 6:00 PM con 6 partidos
+      await quedadasRef.add({
+        'lugar': 'El Maracaná',
         'fecha': Timestamp.now(),
         'hora': '18:00',
-        'jugadores': [],
-        'equipo1': [],
-        'equipo2': [],
-      });
-      await quedadasRef.add({
-        'lugar': 'Club de Tenis y Padel',
-        'fecha': Timestamp.fromDate(DateTime.now().add(const Duration(days: 1))),
-        'hora': '20:00',
-        'jugadores': [],
-        'equipo1': [],
-        'equipo2': [],
+        'partidos': List.generate(6, (index) => {
+          'equipo1': [],
+          'equipo2': [],
+          'estado': 'disponible',
+          'resultado': null,
+        }),
       });
     }
   }


### PR DESCRIPTION
- Modificar el modelo de datos para que una quedada contenga una lista de partidos.
- Actualizar la página de la sala para mostrar los partidos y permitir a los usuarios unirse.
- Crear datos de ejemplo con la nueva estructura.