### PR TITLE
feat: Add booking page and validation

### DIFF
--- a/lib/features/pages/_pages.dart
+++ b/lib/features/pages/_pages.dart
@@ -1,4 +1,5 @@
 
+export 'package:padel_app/features/pages/booking_page.dart';
 export 'package:padel_app/features/pages/profile_page.dart';
 export 'package:padel_app/features/pages/start_page.dart';
 export 'package:padel_app/features/pages/table_page.dart';

--- a/lib/features/pages/booking_page.dart
+++ b/lib/features/pages/booking_page.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:padel_app/data/models/quedada_model.dart';
+import 'package:padel_app/features/design/app_colors.dart';
+import 'package:padel_app/features/pages/home_page.dart';
+
+class BookingPage extends StatefulWidget {
+  final String canchaNombre;
+  final String fecha;
+  final String hora;
+
+  const BookingPage({
+    Key? key,
+    required this.canchaNombre,
+    required this.fecha,
+    required this.hora,
+  }) : super(key: key);
+
+  @override
+  _BookingPageState createState() => _BookingPageState();
+}
+
+class _BookingPageState extends State<BookingPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nombreController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Reservar Pista'),
+        centerTitle: true,
+        backgroundColor: AppColors.primaryBlue,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nombreController,
+                decoration: const InputDecoration(labelText: 'Tu Nombre'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor, introduce tu nombre';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    _reservarPista();
+                  }
+                },
+                child: const Text('Confirmar Reserva'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _reservarPista() {
+    final nuevaQuedada = Quedada(
+      id: '', // Firestore will generate the ID
+      lugar: widget.canchaNombre,
+      fecha: widget.fecha,
+      hora: widget.hora,
+      equipo1: [_nombreController.text, ''],
+      equipo2: ['', ''],
+      estado: 'En espera',
+      ganador: 'Por definir',
+      set1: 'No disponible',
+      set2: 'No disponible',
+      set3: 'No disponible',
+    );
+
+    FirebaseFirestore.instance
+        .collection('quedadas')
+        .add(nuevaQuedada.toFirestore())
+        .then((_) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Reserva confirmada')),
+      );
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const HomePage()),
+        (Route<dynamic> route) => false,
+      );
+    }).catchError((error) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al reservar: $error')),
+      );
+    });
+  }
+}

--- a/lib/features/pages/room_page.dart
+++ b/lib/features/pages/room_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:padel_app/data/models/cancha_model.dart';
 import 'package:padel_app/data/models/quedada_model.dart';
 import 'package:padel_app/features/design/app_colors.dart';
+import 'package:padel_app/features/pages/booking_page.dart';
 import 'package:padel_app/features/pages/canchas_page.dart';
 
 class RoomPage extends StatefulWidget {
@@ -129,7 +130,35 @@ class _RoomPageState extends State<RoomPage> {
                           subtitle: Text(estado),
                           trailing: Icon(Icons.circle, color: color),
                           onTap: () {
-                            if (quedadaExistente.id.isNotEmpty) {
+                            if (quedadaExistente.id.isEmpty) {
+                              // Disponible
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => BookingPage(
+                                    canchaNombre: cancha.nombre,
+                                    fecha: formattedDate,
+                                    hora: horaString,
+                                  ),
+                                ),
+                              );
+                            } else if (quedadaExistente.estado == 'En transcurso') {
+                              showDialog(
+                                context: context,
+                                builder: (context) => AlertDialog(
+                                  title: const Text('Horario no disponible'),
+                                  content: const Text(
+                                      'Esta hora ya está reservada y el partido está en transcurso.'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.of(context).pop(),
+                                      child: const Text('Aceptar'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            } else {
+                              // Navegar a los detalles de la quedada si no está en transcurso
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(


### PR DESCRIPTION
This commit introduces a new booking page that allows you to book a court.

The new `booking_page.dart` file contains the UI for the booking form, where you can enter your name to book a court. The date, time, and location are pre-filled from the `room_page`.

The booking logic creates a new booking in Firestore with the status "En espera" and other default values.

Validation has been added to the `room_page.dart` to prevent you from booking a time slot that is already "En curso". An alert dialog is shown to you in this case.

The `room_page.dart` has been updated to navigate to the new booking page when you tap on an available time slot.