### PR TITLE
feat: Crear modelos de datos para rankings

### DIFF
--- a/lib/data/jugador_stats.dart
+++ b/lib/data/jugador_stats.dart
@@ -1,23 +1,47 @@
-import 'package:flutter/material.dart';
-
 class JugadorStats {
-  final TextEditingController nombreController;
-  final String logoUrl;
-  final TextEditingController puntosPosController;
-  final TextEditingController porcentajeController;
-  final TextEditingController asistenciasController;
-  final TextEditingController ptsController;
+  final int asistencias;
+  final int bonificaciones;
+  final int efectividad;
+  final int penalizacion;
+  final int puntos;
+  final int subcategoria;
+  final String nombre;
+  final String uid;
 
   JugadorStats({
-    required String nombre,
-    required this.logoUrl,
-    required String puntosPos,
-    required String porcentaje,
-    required String asistencias,
-    required String pts,
-  })  : nombreController = TextEditingController(text: nombre),
-        puntosPosController = TextEditingController(text: puntosPos),
-        porcentajeController = TextEditingController(text: porcentaje),
-        asistenciasController = TextEditingController(text: asistencias),
-        ptsController = TextEditingController(text: pts);
+    this.asistencias = 0,
+    this.bonificaciones = 0,
+    this.efectividad = 0,
+    this.penalizacion = 0,
+    this.puntos = 0,
+    this.subcategoria = 0,
+    this.nombre = '',
+    this.uid = '',
+  });
+
+  factory JugadorStats.fromJson(Map<String, dynamic> json) {
+    return JugadorStats(
+      asistencias: json['asistencias'] as int? ?? 0,
+      bonificaciones: json['bonificaciones'] as int? ?? 0,
+      efectividad: json['efectividad'] as int? ?? 0,
+      penalizacion: json['penalizacion'] as int? ?? 0,
+      puntos: json['puntos'] as int? ?? 0,
+      subcategoria: json['subcategoria'] as int? ?? 0,
+      nombre: json['nombre'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'asistencias': asistencias,
+      'bonificaciones': bonificaciones,
+      'efectividad': efectividad,
+      'penalizacion': penalizacion,
+      'puntos': puntos,
+      'subcategoria': subcategoria,
+      'nombre': nombre,
+      'uid': uid,
+    };
+  }
 }

--- a/lib/data/models/rank_ciudades_model.dart
+++ b/lib/data/models/rank_ciudades_model.dart
@@ -1,0 +1,32 @@
+import 'package:padel_app/data/jugador_stats.dart';
+
+class RankCiudad {
+  final String ciudad;
+  final Map<String, JugadorStats> jugadores;
+
+  RankCiudad({
+    required this.ciudad,
+    required this.jugadores,
+  });
+
+  factory RankCiudad.fromJson(Map<String, dynamic> json) {
+    var jugadoresMap = <String, JugadorStats>{};
+    if (json['jugadores'] != null) {
+      (json['jugadores'] as Map<String, dynamic>).forEach((key, value) {
+        jugadoresMap[key] = JugadorStats.fromJson(value as Map<String, dynamic>);
+      });
+    }
+
+    return RankCiudad(
+      ciudad: json['ciudad'] as String? ?? '',
+      jugadores: jugadoresMap,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'ciudad': ciudad,
+      'jugadores': jugadores.map((key, value) => MapEntry(key, value.toJson())),
+    };
+  }
+}

--- a/lib/data/models/rank_clubes_model.dart
+++ b/lib/data/models/rank_clubes_model.dart
@@ -1,0 +1,32 @@
+import 'package:padel_app/data/jugador_stats.dart';
+
+class RankClub {
+  final String club;
+  final Map<String, JugadorStats> jugadores;
+
+  RankClub({
+    required this.club,
+    required this.jugadores,
+  });
+
+  factory RankClub.fromJson(Map<String, dynamic> json) {
+    var jugadoresMap = <String, JugadorStats>{};
+    if (json['jugadores'] != null) {
+      (json['jugadores'] as Map<String, dynamic>).forEach((key, value) {
+        jugadoresMap[key] = JugadorStats.fromJson(value as Map<String, dynamic>);
+      });
+    }
+
+    return RankClub(
+      club: json['club'] as String? ?? '',
+      jugadores: jugadoresMap,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'club': club,
+      'jugadores': jugadores.map((key, value) => MapEntry(key, value.toJson())),
+    };
+  }
+}

--- a/lib/data/models/rank_whatsapp_model.dart
+++ b/lib/data/models/rank_whatsapp_model.dart
@@ -1,0 +1,32 @@
+import 'package:padel_app/data/jugador_stats.dart';
+
+class RankWhatsapp {
+  final String nombre_grupo;
+  final Map<String, JugadorStats> integrantes;
+
+  RankWhatsapp({
+    required this.nombre_grupo,
+    required this.integrantes,
+  });
+
+  factory RankWhatsapp.fromJson(Map<String, dynamic> json) {
+    var integrantesMap = <String, JugadorStats>{};
+    if (json['integrantes'] != null) {
+      (json['integrantes'] as Map<String, dynamic>).forEach((key, value) {
+        integrantesMap[key] = JugadorStats.fromJson(value as Map<String, dynamic>);
+      });
+    }
+
+    return RankWhatsapp(
+      nombre_grupo: json['nombre_grupo'] as String? ?? '',
+      integrantes: integrantesMap,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'nombre_grupo': nombre_grupo,
+      'integrantes': integrantes.map((key, value) => MapEntry(key, value.toJson())),
+    };
+  }
+}


### PR DESCRIPTION
Se añaden los modelos de datos para las nuevas colecciones de Firebase:
- rank_whatsapp
- rank_clubes
- rank_ciudades

Se ha creado un modelo reutilizable `JugadorStats` para encapsular las estadísticas de los jugadores, que se utiliza en los tres nuevos modelos de ranking.

Los nuevos modelos incluyen la lógica de serialización y deserialización (`fromJson`, `toJson`) para interactuar con Firestore.