### PR TITLE
Fix(stats): Maneja la carga de estadísticas de jugador inexistentes

### DIFF
--- a/lib/features/pages/edit_profile_data_page.dart
+++ b/lib/features/pages/edit_profile_data_page.dart
@@ -81,16 +81,16 @@ class _EditProfileDataPageState extends State<EditProfileDataPage> {
 
         if (jugadorData != null) {
           _jugadorStats = JugadorStats.fromJson(jugadorData);
-          _asistenciasController.text = _jugadorStats!.asistencias.toString();
-          _bonificacionesController.text = _jugadorStats!.bonificaciones.toString();
-          _efectividadController.text = _jugadorStats!.efectividad.toString();
-          _penalizacionesController.text = _jugadorStats!.penalizacion.toString();
-          _puntosController.text = _jugadorStats!.puntos.toString();
-          _subcategoriaController.text = _jugadorStats!.subcategoria.toString();
-          _nombreController.text = _jugadorStats!.nombre;
         } else {
-          throw Exception('Estadísticas de jugador no encontradas para el usuario.');
+          _jugadorStats = JugadorStats(uid: widget.userId);
         }
+        _asistenciasController.text = _jugadorStats!.asistencias.toString();
+        _bonificacionesController.text = _jugadorStats!.bonificaciones.toString();
+        _efectividadController.text = _jugadorStats!.efectividad.toString();
+        _penalizacionesController.text = _jugadorStats!.penalizacion.toString();
+        _puntosController.text = _jugadorStats!.puntos.toString();
+        _subcategoriaController.text = _jugadorStats!.subcategoria.toString();
+        _nombreController.text = _jugadorStats!.nombre;
       } else {
         throw Exception('Documento de ranking no encontrado.');
       }


### PR DESCRIPTION
La aplicación lanzaba una excepción en la página de edición de perfil si no tenías estadísticas de jugador guardadas previamente. Esto te impedía añadir tus estadísticas por primera vez.

Este cambio modifica la lógica de carga de datos para crear un nuevo objeto `JugadorStats` vacío si no se encuentra ninguno para ti. Esto permite que la página se cargue correctamente y que puedas introducir y guardar tus estadísticas.