### PR TITLE
Fix(stats): Soluciona todos los problemas con la carga y edición de e…

### DIFF
--- a/lib/data/jugador_stats.dart
+++ b/lib/data/jugador_stats.dart
@@ -15,17 +15,9 @@ class JugadorStats {
     this.penalizacion = 0,
     this.puntos = 0,
     this.subcategoria = 0,
-    required this.nombre,
-    required this.uid,
+    this.nombre = '',
+    this.uid = '',
   });
-
-  JugadorStats.empty({this.nombre = '', this.uid = ''})
-      : asistencias = 0,
-        bonificaciones = 0,
-        efectividad = 0,
-        penalizacion = 0,
-        puntos = 0,
-        subcategoria = 0;
 
   factory JugadorStats.fromJson(Map<String, dynamic> json) {
     return JugadorStats(

--- a/lib/features/pages/edit_profile_data_page.dart
+++ b/lib/features/pages/edit_profile_data_page.dart
@@ -80,7 +80,7 @@ class _EditProfileDataPageState extends State<EditProfileDataPage> {
       if (doc.exists) {
         final data = doc.data() as Map<String, dynamic>;
         final statsMap = data[widget.mapKey] as Map<String, dynamic>? ?? {};
-        final jugadorData = statsMap[widget.userId]as Map<String, dynamic>?;
+        final jugadorData = statsMap[widget.userId] as Map<String, dynamic>?;
 
         if (jugadorData != null) {
           _jugadorStats = JugadorStats.fromJson(jugadorData);
@@ -88,10 +88,10 @@ class _EditProfileDataPageState extends State<EditProfileDataPage> {
             _jugadorStats = _jugadorStats!.copyWith(nombre: userName);
           }
         } else {
-          _jugadorStats = JugadorStats.empty(uid: widget.userId, nombre: userName);
+          _jugadorStats = JugadorStats(uid: widget.userId, nombre: userName);
         }
       } else {
-        _jugadorStats = JugadorStats.empty(uid: widget.userId, nombre: userName);
+        _jugadorStats = JugadorStats(uid: widget.userId, nombre: userName);
       }
 
       _asistenciasController.text = _jugadorStats!.asistencias.toString();
@@ -122,7 +122,6 @@ class _EditProfileDataPageState extends State<EditProfileDataPage> {
       final efectividadValue = int.tryParse(_efectividadController.text) ?? _jugadorStats!.efectividad;
 
       JugadorStats statsActualizado = _jugadorStats!.copyWith(
-        nombre: _jugadorStats!.nombre,
         asistencias: int.tryParse(_asistenciasController.text) ?? _jugadorStats!.asistencias,
         bonificaciones: int.tryParse(_bonificacionesController.text) ?? _jugadorStats!.bonificaciones,
         efectividad: efectividadValue,


### PR DESCRIPTION
…stadísticas de jugador

Este cambio corrige varios problemas relacionados con la edición de las estadísticas de los jugadores:

- La aplicación ya no se bloquea cuando un usuario no tiene estadísticas existentes. Ahora inicializa correctamente un objeto de estadísticas vacío.
- Las estadísticas de los jugadores existentes ahora se muestran correctamente al editar.
- El nombre del jugador ahora se obtiene de su perfil de usuario y se muestra como de solo lectura, evitando que se modifique en esta pantalla.
- El constructor de `JugadorStats` ya no requiere el campo `nombre`, solucionando un problema que impedía guardar los cambios.

El modelo `JugadorStats` ha sido actualizado para soportar estos cambios.