### PR TITLE
He corregido un error en la edición de estadísticas que causaba que e…

### DIFF
--- a/lib/features/pages/table_page.dart
+++ b/lib/features/pages/table_page.dart
@@ -79,9 +79,9 @@ class _RankingTableState extends State<RankingTable> {
 
         statsMap.forEach((uid, statsData) {
           var statsWithUid = Map<String, dynamic>.from(statsData);
-          if (statsWithUid['uid'] == null || statsWithUid['uid'] == '') {
-            statsWithUid['uid'] = uid;
-          }
+          // Se asigna el UID desde la clave del mapa para asegurar consistencia.
+          // Esto evita problemas si el UID dentro del objeto no coincide con la clave.
+          statsWithUid['uid'] = uid;
           final stats = JugadorStats.fromJson(statsWithUid);
           allStats.add(JugadorStatsConContexto(
             stats: stats,


### PR DESCRIPTION
…l formulario apareciera con ceros y se creara un nuevo registro en lugar de actualizar.

El problema se debía a una inconsistencia de datos en Firebase, donde el campo `uid` dentro de un objeto de estadísticas de jugador no siempre coincidía con la clave del mapa que lo contenía. El código anterior confiaba en el campo `uid` interno, lo que llevaba a fallos al buscar los datos para la edición.

Para solucionarlo, he reforzado la lógica de carga de datos en `table_page.dart`. Ahora, el `uid` del jugador se asigna incondicionalmente a partir de la clave del mapa de Firebase, asegurando que el identificador correcto se utilice en todo el flujo de edición. Esto resuelve el problema de carga y evita la creación de registros duplicados al guardar.