### PR TITLE
Corregí el error en el formulario de edición de estadísticas donde lo…

### DIFF
--- a/lib/features/pages/table_page.dart
+++ b/lib/features/pages/table_page.dart
@@ -79,9 +79,9 @@ class _RankingTableState extends State<RankingTable> {
 
         statsMap.forEach((uid, statsData) {
           var statsWithUid = Map<String, dynamic>.from(statsData);
-          // Se asigna el UID desde la clave del mapa para asegurar consistencia.
-          // Esto evita problemas si el UID dentro del objeto no coincide con la clave.
-          statsWithUid['uid'] = uid;
+          if (statsWithUid['uid'] == null || statsWithUid['uid'] == '') {
+            statsWithUid['uid'] = uid;
+          }
           final stats = JugadorStats.fromJson(statsWithUid);
           allStats.add(JugadorStatsConContexto(
             stats: stats,


### PR DESCRIPTION
…s datos del jugador no se cargaban correctamente y al guardar se creaba un nuevo registro.

Este error era causado por una inconsistencia en los datos de Firebase, donde el `uid` de autenticación de un usuario no coincidía con la clave bajo la cual se almacenaban sus estadísticas en un mapa anidado.

La solución implementa una lógica de búsqueda más robusta en `edit_profile_data_page.dart`:
1.  Al cargar los datos, el formulario ahora itera sobre el mapa de estadísticas para encontrar al jugador basándose en su `uid` de autenticación, en lugar de asumir que la clave del mapa es la misma.
2.  Se guarda la clave real del mapa del jugador encontrado.
3.  Al guardar los cambios, se utiliza esta clave real para asegurar que el registro correcto sea actualizado, evitando la creación de duplicados.