### PR TITLE
I've implemented navigation for the ranking tables.

### DIFF
--- a/lib/features/pages/_pages.dart
+++ b/lib/features/pages/_pages.dart
@@ -8,3 +8,5 @@ export 'package:padel_app/features/pages/landing_page.dart';
 export 'package:padel_app/features/pages/login_page.dart';
 export 'package:padel_app/features/pages/register_page.dart';
 export 'package:padel_app/features/pages/auth_wrapper.dart';
+export 'package:padel_app/features/pages/ranking_list_page.dart';
+export 'package:padel_app/features/pages/ranking_detail_page.dart';

--- a/lib/features/pages/ranking_detail_page.dart
+++ b/lib/features/pages/ranking_detail_page.dart
@@ -1,0 +1,133 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:padel_app/data/jugador_stats.dart';
+import 'package:padel_app/features/design/app_colors.dart';
+import 'package:padel_app/features/pages/table_page.dart';
+import 'package:provider/provider.dart';
+import 'package:padel_app/data/viewmodels/auth_viewmodel.dart';
+
+class RankingDetailPage extends StatefulWidget {
+  final String collectionName;
+  final String docId;
+
+  const RankingDetailPage({
+    super.key,
+    required this.collectionName,
+    required this.docId,
+  });
+
+  @override
+  State<RankingDetailPage> createState() => _RankingDetailPageState();
+}
+
+class _RankingDetailPageState extends State<RankingDetailPage> {
+  late Stream<List<JugadorStatsConContexto>> _rankStatsStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _rankStatsStream = _getRankStatsStream();
+  }
+
+  String get mapKey {
+    switch (widget.collectionName) {
+      case 'rank_clubes':
+        return 'jugadores';
+      case 'rank_ciudades':
+        return 'jugadores';
+      case 'rank_whatsapp':
+        return 'integrantes';
+      default:
+        return 'jugadores';
+    }
+  }
+
+  Stream<List<JugadorStatsConContexto>> _getRankStatsStream() {
+    return FirebaseFirestore.instance
+        .collection(widget.collectionName)
+        .doc(widget.docId)
+        .snapshots()
+        .map((doc) {
+      if (!doc.exists) {
+        return <JugadorStatsConContexto>[];
+      }
+
+      List<JugadorStatsConContexto> allStats = [];
+      final data = doc.data();
+      final statsMap = data?[mapKey] as Map<String, dynamic>? ?? {};
+
+      statsMap.forEach((uid, statsData) {
+        var statsWithUid = Map<String, dynamic>.from(statsData);
+        if (statsWithUid['uid'] == null || statsWithUid['uid'] == '') {
+          statsWithUid['uid'] = uid;
+        }
+        final stats = JugadorStats.fromJson(statsWithUid);
+        allStats.add(JugadorStatsConContexto(
+          stats: stats,
+          docId: doc.id,
+          collectionName: widget.collectionName,
+          mapKey: mapKey,
+        ));
+      });
+
+      allStats.sort((a, b) => b.stats.puntos.compareTo(a.stats.puntos));
+      return allStats;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authViewModel = Provider.of<AuthViewModel>(context);
+
+    return Scaffold(
+      backgroundColor: AppColors.primaryBlack,
+      appBar: AppBar(
+        title: Text(widget.docId, style: GoogleFonts.lato(color: AppColors.textWhite)),
+        centerTitle: true,
+        backgroundColor: AppColors.secondBlack,
+        iconTheme: const IconThemeData(color: AppColors.textWhite),
+      ),
+      body: StreamBuilder<List<JugadorStatsConContexto>>(
+        stream: _rankStatsStream,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator(color: AppColors.primaryGreen));
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}', style: GoogleFonts.lato(color: AppColors.textWhite)));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return Center(child: Text('No hay datos en esta tabla.', style: GoogleFonts.lato(color: AppColors.textWhite)));
+          }
+
+          final List<JugadorStatsConContexto> statsList = snapshot.data!;
+          final List<Map<String, dynamic>> tableData = statsList.map((statsConContexto) {
+            final stats = statsConContexto.stats;
+            return {
+              'JUGADOR': stats.nombre,
+              '%': '${stats.efectividad}%',
+              'ASIST': stats.asistencias,
+              'PTS': stats.puntos,
+              'SUB CTG': stats.subcategoria,
+              'BON': stats.bonificaciones,
+              'PEN': stats.penalizacion,
+              'id': stats.uid,
+              'isCurrentUser': authViewModel.currentUser?.uid == stats.uid,
+              'docId': statsConContexto.docId,
+              'collectionName': statsConContexto.collectionName,
+              'mapKey': statsConContexto.mapKey,
+            };
+          }).toList();
+
+          return SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: TablaDatosJugador(datos: tableData),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/pages/ranking_list_page.dart
+++ b/lib/features/pages/ranking_list_page.dart
@@ -1,0 +1,67 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:padel_app/features/design/app_colors.dart';
+import 'package:padel_app/features/pages/ranking_detail_page.dart';
+
+class RankingListPage extends StatelessWidget {
+  final String collectionName;
+  final String title;
+
+  const RankingListPage({
+    super.key,
+    required this.collectionName,
+    required this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.primaryBlack,
+      appBar: AppBar(
+        title: Text(title, style: GoogleFonts.lato(color: AppColors.textWhite)),
+        centerTitle: true,
+        backgroundColor: AppColors.secondBlack,
+        iconTheme: const IconThemeData(color: AppColors.textWhite),
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance.collection(collectionName).snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator(color: AppColors.primaryGreen));
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}', style: GoogleFonts.lato(color: AppColors.textWhite)));
+          }
+          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+            return Center(child: Text('No hay tablas en esta categoría.', style: GoogleFonts.lato(color: AppColors.textWhite)));
+          }
+
+          final documents = snapshot.data!.docs;
+
+          return ListView.builder(
+            itemCount: documents.length,
+            itemBuilder: (context, index) {
+              final doc = documents[index];
+              return ListTile(
+                title: Text(doc.id, style: GoogleFonts.lato(color: AppColors.textWhite)),
+                trailing: const Icon(Icons.arrow_forward_ios, color: AppColors.textWhite),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => RankingDetailPage(
+                        collectionName: collectionName,
+                        docId: doc.id,
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- I created a new page to display a list of tables (documents) from a Firestore collection.
- I created a new page to display the details of a selected table.
- I modified the main table page to navigate to the new list page for each ranking category (Clubes, Ciudades, WhatsApp).
- I removed the old combined table display logic.