### PR TITLE
feat: Display name in ranking list

### DIFF
--- a/lib/features/pages/ranking_detail_page.dart
+++ b/lib/features/pages/ranking_detail_page.dart
@@ -10,11 +10,13 @@ import 'package:padel_app/data/viewmodels/auth_viewmodel.dart';
 class RankingDetailPage extends StatefulWidget {
   final String collectionName;
   final String docId;
+  final String title;
 
   const RankingDetailPage({
     super.key,
     required this.collectionName,
     required this.docId,
+    required this.title,
   });
 
   @override
@@ -83,7 +85,7 @@ class _RankingDetailPageState extends State<RankingDetailPage> {
     return Scaffold(
       backgroundColor: AppColors.primaryBlack,
       appBar: AppBar(
-        title: Text(widget.docId, style: GoogleFonts.lato(color: AppColors.textWhite)),
+        title: Text(widget.title, style: GoogleFonts.lato(color: AppColors.textWhite)),
         centerTitle: true,
         backgroundColor: AppColors.secondBlack,
         iconTheme: const IconThemeData(color: AppColors.textWhite),

--- a/lib/features/pages/ranking_list_page.dart
+++ b/lib/features/pages/ranking_list_page.dart
@@ -43,8 +43,24 @@ class RankingListPage extends StatelessWidget {
             itemCount: documents.length,
             itemBuilder: (context, index) {
               final doc = documents[index];
+              final data = doc.data() as Map<String, dynamic>;
+              String name;
+              switch (collectionName) {
+                case 'rank_ciudades':
+                  name = data['ciudad'] ?? doc.id;
+                  break;
+                case 'rank_clubes':
+                  name = data['club'] ?? doc.id;
+                  break;
+                case 'rank_whatsapp':
+                  name = data['nombre_grupo'] ?? doc.id;
+                  break;
+                default:
+                  name = doc.id;
+              }
+
               return ListTile(
-                title: Text(doc.id, style: GoogleFonts.lato(color: AppColors.textWhite)),
+                title: Text(name, style: GoogleFonts.lato(color: AppColors.textWhite)),
                 trailing: const Icon(Icons.arrow_forward_ios, color: AppColors.textWhite),
                 onTap: () {
                   Navigator.push(
@@ -53,6 +69,7 @@ class RankingListPage extends StatelessWidget {
                       builder: (context) => RankingDetailPage(
                         collectionName: collectionName,
                         docId: doc.id,
+                        title: name,
                       ),
                     ),
                   );


### PR DESCRIPTION
- I've modified `ranking_list_page.dart` to fetch and display the name of the city, club, or WhatsApp group from the document data instead of the document ID.
- I've passed the fetched name to the `ranking_detail_page.dart`.
- I've modified `ranking_detail_page.dart` to accept the name as a `title` parameter and display it in the AppBar.