### PR TITLE
feat: Implementar lógica y UI para administradores

### DIFF
--- a/lib/data/repositories/ranking_repository.dart
+++ b/lib/data/repositories/ranking_repository.dart
@@ -114,4 +114,26 @@ class RankingRepository {
       throw Exception('Error al añadir jugadores al ranking: $e');
     }
   }
+
+  Future<void> updatePlayerStats({
+    required String collectionName,
+    required String docId,
+    required String mapKey,
+    required String statsMapKey,
+    required JugadorStats stats,
+  }) async {
+    try {
+      final currentUser = await _authRepository.obtenerDatosUsuarioActual();
+      if (currentUser == null || !currentUser.admin) {
+        throw Exception('No tienes permisos de administrador.');
+      }
+
+      await _firestore
+          .collection(collectionName)
+          .doc(docId)
+          .update({'$mapKey.$statsMapKey': stats.toJson()});
+    } catch (e) {
+      throw Exception('Error al actualizar las estadísticas: $e');
+    }
+  }
 }

--- a/lib/data/viewmodels/auth_viewmodel.dart
+++ b/lib/data/viewmodels/auth_viewmodel.dart
@@ -7,7 +7,9 @@ class AuthViewModel extends ChangeNotifier {
   final AuthRepository _authRepository;
 
   AuthViewModel({required AuthRepository authRepository})
-      : _authRepository = authRepository;
+      : _authRepository = authRepository {
+    _checkAdminStatus();
+  }
 
   bool _isLoading = false;
   bool get isLoading => _isLoading;
@@ -15,8 +17,17 @@ class AuthViewModel extends ChangeNotifier {
   String? _errorMessage;
   String? get errorMessage => _errorMessage;
 
+  bool _isAdmin = false;
+  bool get isAdmin => _isAdmin;
+
   User? get currentUser => _authRepository.currentUser;
   Stream<User?> get authStateChanges => _authRepository.authStateChanges;
+
+  Future<void> _checkAdminStatus() async {
+    final usuario = await _authRepository.obtenerDatosUsuarioActual();
+    _isAdmin = usuario?.admin ?? false;
+    notifyListeners();
+  }
 
   void _setLoading(bool loading) {
     _isLoading = loading;
@@ -76,6 +87,7 @@ class AuthViewModel extends ChangeNotifier {
     _clearError();
     try {
       await _authRepository.iniciarSesion(email, password);
+      await _checkAdminStatus();
       _setLoading(false);
       return true;
     } catch (e) {
@@ -90,6 +102,7 @@ class AuthViewModel extends ChangeNotifier {
     _clearError();
     try {
       await _authRepository.cerrarSesion();
+      _isAdmin = false;
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();

--- a/lib/features/pages/edit_profile_data_page.dart
+++ b/lib/features/pages/edit_profile_data_page.dart
@@ -1,7 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:padel_app/data/repositories/ranking_repository.dart';
 import 'package:padel_app/features/design/app_colors.dart';
+import 'package:provider/provider.dart';
 
 import '../../data/jugador_stats.dart';
 
@@ -156,10 +158,15 @@ class _EditProfileDataPageState extends State<EditProfileDataPage> {
       );
 
       try {
-        await FirebaseFirestore.instance
-            .collection(widget.sourceCollection)
-            .doc(widget.docId)
-            .update({'${widget.mapKey}.$_statsMapKey': statsActualizado.toJson()});
+        final rankingRepository =
+            Provider.of<RankingRepository>(context, listen: false);
+        await rankingRepository.updatePlayerStats(
+          collectionName: widget.sourceCollection,
+          docId: widget.docId,
+          mapKey: widget.mapKey,
+          statsMapKey: _statsMapKey!,
+          stats: statsActualizado,
+        );
 
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/pages/ranking_list_page.dart
+++ b/lib/features/pages/ranking_list_page.dart
@@ -1,9 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:padel_app/features/design/app_colors.dart';
+import 'package:padel_app/data/viewmodels/auth_viewmodel.dart';
+import 'package.padel_app/features/design/app_colors.dart';
 import 'package:padel_app/features/pages/add_ranking_page.dart';
 import 'package:padel_app/features/pages/ranking_detail_page.dart';
+import 'package:provider/provider.dart';
 
 class RankingListPage extends StatelessWidget {
   final String collectionName;
@@ -25,23 +27,30 @@ class RankingListPage extends StatelessWidget {
         backgroundColor: AppColors.primaryGreen,
         iconTheme: const IconThemeData(color: AppColors.textWhite),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => AddRankingPage(
-                collectionName: collectionName,
-                title: title,
-              ),
-            ),
-          );
+      floatingActionButton: Consumer<AuthViewModel>(
+        builder: (context, authViewModel, child) {
+          return authViewModel.isAdmin
+              ? FloatingActionButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => AddRankingPage(
+                          collectionName: collectionName,
+                          title: title,
+                        ),
+                      ),
+                    );
+                  },
+                  backgroundColor: AppColors.primaryGreen,
+                  child: const Icon(Icons.add, color: AppColors.textWhite),
+                )
+              : null;
         },
-        backgroundColor: AppColors.primaryGreen,
-        child: const Icon(Icons.add, color: AppColors.textWhite),
       ),
       body: StreamBuilder<QuerySnapshot>(
-        stream: FirebaseFirestore.instance.collection(collectionName).snapshots(),
+        stream:
+            FirebaseFirestore.instance.collection(collectionName).snapshots(),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator(color: AppColors.primaryGreen));

--- a/lib/features/pages/table_page.dart
+++ b/lib/features/pages/table_page.dart
@@ -397,6 +397,7 @@ class TablaDatosJugador extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final authViewModel = Provider.of<AuthViewModel>(context, listen: false);
     final size = MediaQuery.of(context).size;
 
     TextStyle headerTextStyle = GoogleFonts.lato(
@@ -407,6 +408,20 @@ class TablaDatosJugador extends StatelessWidget {
     TextStyle cellTextStyle = GoogleFonts.lato(
       color: AppColors.textWhite,
     );
+
+    List<DataColumn> columns = [
+      DataColumn(label: Text('JUGADOR', style: headerTextStyle)),
+      DataColumn(label: Text('EFEC', style: headerTextStyle)),
+      DataColumn(label: Text('ASIST', style: headerTextStyle)),
+      DataColumn(label: Text('PTS', style: headerTextStyle)),
+      DataColumn(label: Text('SUB CTG', style: headerTextStyle)),
+      DataColumn(label: Text('BON', style: headerTextStyle)),
+      DataColumn(label: Text('PEN', style: headerTextStyle)),
+    ];
+
+    if (authViewModel.isAdmin) {
+      columns.add(DataColumn(label: Text('ACCIONES', style: headerTextStyle)));
+    }
 
     return Container(
       width: size.width * 0.9,
@@ -427,34 +442,29 @@ class TablaDatosJugador extends StatelessWidget {
             dataRowColor: WidgetStateProperty.resolveWith<Color?>(
               (Set<WidgetState> states) => AppColors.secondBlack,
             ),
-            columns: <DataColumn>[
-              DataColumn(label: Text('JUGADOR', style: headerTextStyle)),
-              DataColumn(label: Text('EFEC', style: headerTextStyle)),
-              DataColumn(label: Text('ASIST', style: headerTextStyle)),
-              DataColumn(label: Text('PTS', style: headerTextStyle)),
-              DataColumn(label: Text('SUB CTG', style: headerTextStyle)),
-              DataColumn(label: Text('BON', style: headerTextStyle)),
-              DataColumn(label: Text('PEN', style: headerTextStyle)),
-              DataColumn(label: Text('ACCIONES', style: headerTextStyle)),
-            ],
+            columns: columns,
             rows: datos.map((fila) {
-              bool isCurrentUser = fila['isCurrentUser'] ?? false;
               String userId = fila['id']?.toString() ?? '';
-              bool isEditable = fila['docId'] != null; // La fila es editable si tiene contexto
+              bool isEditable = fila['docId'] != null;
 
-              return DataRow(
-                cells: <DataCell>[
-                  DataCell(Text(fila['JUGADOR'].toString(), style: cellTextStyle)),
-                  DataCell(Text(fila['%'].toString(), style: cellTextStyle)),
-                  DataCell(Text(fila['ASIST'].toString(), style: cellTextStyle)),
-                  DataCell(Text(fila['PTS'].toString(), style: cellTextStyle)),
-                  DataCell(Text(fila['SUB CTG'].toString(), style: cellTextStyle)),
-                  DataCell(Text(fila['BON'].toString(), style: cellTextStyle)),
-                  DataCell(Text(fila['PEN'].toString(), style: cellTextStyle)),
+              List<DataCell> cells = [
+                DataCell(Text(fila['JUGADOR'].toString(), style: cellTextStyle)),
+                DataCell(Text(fila['%'].toString(), style: cellTextStyle)),
+                DataCell(Text(fila['ASIST'].toString(), style: cellTextStyle)),
+                DataCell(Text(fila['PTS'].toString(), style: cellTextStyle)),
+                DataCell(
+                    Text(fila['SUB CTG'].toString(), style: cellTextStyle)),
+                DataCell(Text(fila['BON'].toString(), style: cellTextStyle)),
+                DataCell(Text(fila['PEN'].toString(), style: cellTextStyle)),
+              ];
+
+              if (authViewModel.isAdmin) {
+                cells.add(
                   DataCell(
-                    (isCurrentUser && userId.isNotEmpty && isEditable)
+                    (userId.isNotEmpty && isEditable)
                         ? IconButton(
-                            icon: const Icon(Icons.edit, color: AppColors.primaryGreen),
+                            icon: const Icon(Icons.edit,
+                                color: AppColors.primaryGreen),
                             onPressed: () {
                               Navigator.push(
                                 context,
@@ -466,16 +476,14 @@ class TablaDatosJugador extends StatelessWidget {
                                     mapKey: fila['mapKey'],
                                   ),
                                 ),
-                              ).then((_) {
-                                // Opcional: recargar datos si es necesario tras la edición.
-                                // Por ejemplo, si la página no se actualiza automáticamente.
-                              });
+                              );
                             },
                           )
                         : Container(),
                   ),
-                ],
-              );
+                );
+              }
+              return DataRow(cells: cells);
             }).toList(),
           ),
         ),


### PR DESCRIPTION
Esta solución implementa un sistema completo de roles de administrador, afectando tanto la lógica de negocio como la interfaz de usuario.

- **Gestión de estado centralizada:** Se añade una propiedad `isAdmin` al `AuthViewModel` que se actualiza con el estado de autenticación del usuario. Esto proporciona una única fuente de verdad para los permisos de administrador.

- **UI condicional:** Los elementos de la interfaz de usuario para acciones de administrador ahora dependen del estado `isAdmin`.
  - El `FloatingActionButton` para crear nuevos rankings solo es visible para administradores.
  - La columna "ACCIONES" en las tablas de ranking, que permite editar a los jugadores, solo es visible para administradores.
  - Se ha eliminado la restricción que solo permitía a los usuarios editarse a sí mismos; ahora los administradores pueden editar a cualquier jugador.

- **Validación en el repositorio:** Se ha añadido validación en el `RankingRepository` para todas las operaciones de escritura y actualización, asegurando que solo los administradores puedan realizar cambios en la base de datos.